### PR TITLE
FW-19212, store fwxcodes and init scripts in external volume

### DIFF
--- a/ucs-server/Dockerfile
+++ b/ucs-server/Dockerfile
@@ -36,13 +36,28 @@ RUN cp -r /fwxserver/DB \
     /usr/local/filewave/certs \
     /usr/local/filewave/fwcld \
     /usr/local/filewave/apache/conf \
+    /usr/local/etc \
     /tmp/filewave/
 
 RUN cp -r /usr/local/filewave/postgresql/conf \
     /tmp/filewave/postgres_conf
 
 # NOTE: grouping directories reduces the number of layers in the final image (a good thing)
-VOLUME [ "/fwxserver/DB", "/fwxserver/Data Folder", "/usr/local/filewave/postgresql/conf", "/usr/local/filewave/apache/conf", "/usr/local/filewave/apache/logs", "/usr/local/filewave/apache/passwords", "/usr/local/filewave/certs", "/usr/local/filewave/fwcld",  "/usr/local/filewave/ipa", "/usr/local/filewave/log", "/usr/local/filewave/media", "/usr/local/filewave/tmp/"]
+VOLUME [ \
+    "/fwxserver/DB", \
+    "/fwxserver/Data Folder", \
+    "/usr/local/filewave/postgresql/conf", \
+    "/usr/local/filewave/apache/conf", \
+    "/usr/local/filewave/apache/logs", \
+    "/usr/local/filewave/apache/passwords", \
+    "/usr/local/filewave/certs", \
+    "/usr/local/filewave/fwcld",  \
+    "/usr/local/filewave/ipa", \
+    "/usr/local/filewave/log", \
+    "/usr/local/filewave/media", \
+    "/usr/local/filewave/tmp/", \
+    "/usr/local/etc" \
+    ]
 
 COPY ./docker-entrypoint.sh /
 # overwrite the supervisord configuration to not use core dumps:

--- a/ucs-server/docker-compose.dev.yml
+++ b/ucs-server/docker-compose.dev.yml
@@ -34,5 +34,6 @@ services:
       - /tmp/docker-test/filewave_log:/usr/local/filewave/log
       - /tmp/docker-test/filewave_tmp:/usr/local/filewave/tmp
       - /tmp/docker-test/server_log:/private/var/log
+      - /tmp/docker-test/system_etc:/usr/local/etc
        
     restart: unless-stopped

--- a/ucs-server/docker-compose.yml
+++ b/ucs-server/docker-compose.yml
@@ -37,5 +37,6 @@ services:
       - /tmp/docker-test/filewave_log:/usr/local/filewave/log
       - /tmp/docker-test/filewave_tmp:/usr/local/filewave/tmp
       - /tmp/docker-test/server_log:/private/var/log
-       
+      - /tmp/docker-test/system_etc:/usr/local/etc
+     
     restart: unless-stopped

--- a/ucs-server/docker-entrypoint.sh
+++ b/ucs-server/docker-entrypoint.sh
@@ -64,6 +64,24 @@ if [ ! "$(ls -A ${FILEWAVE_BASE_DIR}/postgres/conf)" ]; then
     cp -r $TEMP_DIR/postgres_conf/* ${FILEWAVE_BASE_DIR}/postgres/conf/
 fi
 
+ETC_DIR="/usr/local/etc"
+if [ ! "$( ls -A ${ETC_DIR})" ]; then
+    echo $"Restoring ${ETC_DIR} folder"
+    cp -r $TEMP_DIR/etc/* ${ETC_DIR}
+
+    # avoid to copy everytime supervisord scripts
+    mv $TEMP_DIR/etc/filewave $TEMP_DIR/etc/filewave.bak
+fi
+
+# On a new install we need to overwrite supervisord scripts
+if [ -d "$TEMP_DIR/etc/filewave" ]; then
+    echo $"Installing ${ETC_DIR}/filewave folder"
+    cp -r $TEMP_DIR/etc/filewave ${ETC_DIR}
+
+    # avoid to copy everytime supervisord scripts
+    mv $TEMP_DIR/etc/filewave $TEMP_DIR/etc/filewave.bak
+fi
+
 FILEWAVE_TMP_DIR="${FILEWAVE_BASE_DIR}/tmp"
 if [ -f "$FILEWAVE_TMP_DIR/settings_custom.py" ]; then
     echo $"Restoring settings_custom file"


### PR DESCRIPTION
**TESTING:** 

* Install FileWave 12.2.0 on a UCS server
* Update the License and MOdel Update
* Remove FileWave from the UCS server
* Install it again and verify that the license code is still there

*NOTE*: the UCS repository already contains animage built on top of this branch