### PR TITLE
FW-00000 do not force full_tests on db_check

### DIFF
--- a/ucs-server/docker-entrypoint.sh
+++ b/ucs-server/docker-entrypoint.sh
@@ -117,7 +117,7 @@ if [[ -e /usr/local/filewave/tmp/FW_VERSION ]]; then # we create this file in "p
     fi
 
     oldVersion=$(cat /usr/local/filewave/tmp/FW_VERSION)
-    /usr/local/filewave/python/bin/python /usr/local/filewave/django/filewave/fw_util/check_db_errors/check_db_errors.pyc -q -f --ref-version "$oldVersion"
+    /usr/local/filewave/python/bin/python /usr/local/filewave/django/filewave/fw_util/check_db_errors/check_db_errors.pyc -q --ref-version "$oldVersion"
     retVal=$?
     rm -f /usr/local/filewave/tmp/FW_VERSION
     # stopping Postgres


### PR DESCRIPTION
for skipping constraint checks if the installed version isn't is not in the db_references for some reason (i.e: 12.9.2, 13.0.2)